### PR TITLE
User access restructure, remove koku & old content

### DIFF
--- a/doc/assembly_Adding_AWS_sources.adoc
+++ b/doc/assembly_Adding_AWS_sources.adoc
@@ -25,17 +25,13 @@ Before you can add your AWS account to Cost Management as a data source, you mus
 //ADD LINKS TO PROC TOPICS - this is a preview list//
 . An S3 bucket to store cost and usage data reporting for Cost Management
 . An Identity Access Management (IAM) policy and role for Cost Management to process the cost and usage data
-. (Optional) An AWS Simple Notification Service (SNS) alert to trigger processing of cost and usage data when created or updated
 
 
 include::modules/proc_Creating_an_S3_bucket.adoc[]
 include::modules/proc_Enabling_AWS_account_access.adoc[]
-include::modules/proc_Enabling_SNS_notifications.adoc[]
 
 
-
-// This probably needs the title here - 'Adding your AWS account as a source', but I've put the title in the proc topic. Where should it go?
-// Adding an AWS account as a source
+// This probably needs the title here - 'Adding your AWS account as a source', but I've put the title in the procedure topic. Where should it go?
 
 include::modules/proc_Adding_an_AWS_account.adoc[]
 

--- a/doc/modules/con_Access_management.adoc
+++ b/doc/modules/con_Access_management.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // assembly_Adding_AWS_sources.adoc
 [id="con_Access_management_concepts"]
-= Access management concepts
+== Access management concepts
 
 //Future: Add a diagram describing this simply.
 

--- a/doc/modules/proc_Configuring_user_access.adoc
+++ b/doc/modules/proc_Configuring_user_access.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // assembly_Restricting_user_access.adoc
 [id="proc_Configuring_user_access"]
-= Configuring user access
+== Configuring user access
 
 To provide a user with access to resources, create a group, add users to the group, then apply one or more policies to the group. Groups consist of users identified by Red Hat account. 
 

--- a/doc/modules/proc_Creating_an_S3_bucket.adoc
+++ b/doc/modules/proc_Creating_an_S3_bucket.adoc
@@ -14,7 +14,7 @@ To configure your AWS account for cost and usage reporting:
 . In the AWS Billing and Cost Management console, create an AWS Cost and Usage report that includes the following values:
 +
 ----
-Report name: koku
+Report name: cost-management
 Time unit: Hourly
 Include: Resource IDs
 Enable support for…: Redshift, QuickSight


### PR DESCRIPTION
- re-nested content on restricting user access
- removed mentions of Koku to prepare downstream docs build (to re-upstream next week)
- removed SNS topic content on feedback from Chris H -- this doesn't apply to downstream 