### PR TITLE
Update OCP links and remove GCP and future feature from GSG

### DIFF
--- a/downstream/assemblies/assembly_adding_ocp_sources.adoc
+++ b/downstream/assemblies/assembly_adding_ocp_sources.adoc
@@ -26,7 +26,7 @@ To obtain the OpenShift Operator Metering usage data, cost management requires t
 * OpenShift Container Platform 4.3
 * Operator Metering
 +
-Operator Metering is not deployed out of the box in OpenShift Container Platform. See https://docs.openshift.com/container-platform/4.2/metering/metering-installing-metering.html[Installing Metering] in the OpenShift documentation for instructions to install metering from OperatorHub.
+Operator Metering is not deployed out of the box in OpenShift Container Platform. See https://docs.openshift.com/container-platform/4.3/metering/metering-installing-metering.html[Installing Metering] in the OpenShift documentation for instructions to install metering from OperatorHub.
 
 // TODO: * Update to OCP 4.3 throughout, links and refs
 
@@ -78,9 +78,8 @@ https://access.redhat.com/articles/3174981
 See https://access.redhat.com/articles/3174981[How do I Download and Install Red Hat Ansible Engine?] for more information.
 +
 * OpenShift command line tools (oc)
-+ See https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands[Installing the CLI] in the _OpenShift documentation_.
-
-//update OCP 4.3 link
++ 
+See https://docs.openshift.com/container-platform/4.3/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands[Installing the CLI] in the _OpenShift documentation_.
 
 
 include::../modules/obtaining_metering_operator_login_ocp.adoc[]

--- a/downstream/assemblies/assembly_cost_limiting_access_rbac.adoc
+++ b/downstream/assemblies/assembly_cost_limiting_access_rbac.adoc
@@ -44,7 +44,7 @@ Edit and include a brief overview of steps.
 
 [NOTE]
 ====
-To learn more about Red Hat account roles, see See https://access.redhat.com/articles/1757953[Roles and Permissions for Red Hat Subscription Management].
+To learn more about Red Hat account roles, see https://access.redhat.com/articles/1757953[Roles and Permissions for Red Hat Subscription Management].
 ====
 
 include::../modules/adding_a_role_cost_rbac.adoc[leveloffset=+1]

--- a/downstream/assemblies/assembly_managing_cost_data_tagging.adoc
+++ b/downstream/assemblies/assembly_managing_cost_data_tagging.adoc
@@ -38,6 +38,7 @@ include::../modules/con_designing_tagging_strategy.adoc[leveloffset=+1]
 
 include::../modules/ref_tagging_specifications.adoc[leveloffset=+1]
 
+[[additional-resources-tagging]]
 == Additional resources
 
 The following links provide further guidance on tagging for each source type.

--- a/downstream/assemblies/assembly_organizing_cost_data_using_tags.adoc
+++ b/downstream/assemblies/assembly_organizing_cost_data_using_tags.adoc
@@ -39,7 +39,7 @@ include::../modules/adding_tags_to_an_OCP_resource.adoc[leveloffset=+1]
 
 == Next steps
 
-* Refine your tags and tagging strategy to better organize your view of cost data. See the _Managing cost data using tagging_ guide for more details. 
+* Refine your tags and tagging strategy to better organize your view of cost data. See the https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/managing_cost_data_using_tagging/index[_Managing cost data using tagging_] guide for more details. 
 
 
 

--- a/downstream/modules/con_about_cost_management.adoc
+++ b/downstream/modules/con_about_cost_management.adoc
@@ -18,11 +18,8 @@ Cost management is an OpenShift Container Platform service that enables you to b
 
 Cost management allows you to simplify management of resources and costs across various environments, including:
 
-* Public clouds  - such as Amazon Web Services (AWS), Microsoft Azure, Google Compute Engine, IBM Cloud
-* Private clouds - such as Red Hat OpenStack Platform
-* Virtualized environments  - such as Red Hat Virtualization (RHV), VMware
-* Container platforms  - such as OpenShift Container Platform
-* Bare metal servers
+* Public clouds such as Amazon Web Services (AWS) and Microsoft Azure
+* Container platforms such as OpenShift Container Platform
 
 
 The cost management application allows you to:

--- a/downstream/modules/con_designing_tagging_strategy.adoc
+++ b/downstream/modules/con_designing_tagging_strategy.adoc
@@ -60,14 +60,13 @@ Review the resulting reports with your business owner/stakeholders early on to e
 
 == Select your tag terminology
 
-* Name your resources with names that allow you to identify your resources without accessing metadata (many clouds have a guide about how to do this properly; see Additional resources for links), and then continue by adding metadata to it.
+* Name your resources with names that allow you to identify your resources without accessing metadata (many clouds have a guide about how to do this properly; see xref:additional-resources-tagging[] for links), and then continue by adding metadata to it.
 * Map your resources into keys and values. Keys will map to perspectives, while values will define the different options allowed for each key. In some cases, the value will be Null.
 
 [NOTE]
 ====
-Not all sources allow the same identifiers, and have different limitations. See the _Tag specifications by source type_ table in this guide for limitations by source.
+Not all sources allow the same identifiers, and have different limitations. See xref:tag-specifications[] for limitations by source.
 ====
-// add link to table
 
 
 

--- a/downstream/modules/con_how_cost_associates_tags.adoc
+++ b/downstream/modules/con_how_cost_associates_tags.adoc
@@ -16,14 +16,13 @@ Tagging is done in each source before cost management can use the tags to automa
 
 Add your tags or labels to resources belonging to each source. Then, cost management imports the tags by different methods, depending on source type:
 
-* AWS tags must be activated, and are then selected and exported to cost management in the Cost and Usage report. See the _Getting started with cost management_ guide for instructions on activating AWS tags. 
+* AWS tags must be activated, and are then selected and exported to cost management in the Cost and Usage report. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/getting_started_with_cost_management/index#activating_aws_tags[Activating AWS tags for cost management] in the _Getting started with cost management_ guide for instructions on activating AWS tags. 
 * In OpenShift Container Platform, labels are exported by Metering and included in the metrics reports that cost management uses as input. 
 
 [NOTE]
 ====
-See _Getting started with cost management_ for instructions on configuring sources and tags.
+See the https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/getting_started_with_cost_management/index[_Getting started with cost management_] guide for instructions on configuring sources and tags.
 ====
-// Add link to Getting Started Guide
 
 AWS tags and OpenShift labels both consist of key:value pairs. When the key:value pairs match, the AWS and OpenShift costs are automatically associated by cost management. Note that tag matching is not case sensitive: for example, an AWS resource AWS tagged _APP_ and an OpenShift resource tagged _app_ are a match:
 

--- a/downstream/modules/ref_tagging_specifications.adoc
+++ b/downstream/modules/ref_tagging_specifications.adoc
@@ -10,6 +10,7 @@
 // The ID is used as an anchor for linking to the module. Avoid changing it after the module has been published to ensure existing links are not broken.
 [id="ref_tagging_specifications"]
 // The `context` attribute enables module reuse. Every module's ID includes {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide.
+[[tag-specifications]]
 = Tag specifications by source type
 //In the title of a reference module, include nouns that are used in the body text. For example, "Keyboard shortcuts for ___" or "Command options for ___." This helps readers and search engines find the information quickly.
 


### PR DESCRIPTION
inserted links to different cost docs to improve the user flow and findability; updated OCP 4.2 links to 4.3; removed future-feature text in the intro to Getting Started