### PR TITLE
fix to JSON in AWS policy

### DIFF
--- a/downstream/assemblies/assembly_adding_aws_sources.adoc
+++ b/downstream/assemblies/assembly_adding_aws_sources.adoc
@@ -19,7 +19,7 @@ Before you can add your AWS account to cost management as a data source, you mus
 
 As you will complete some of the following steps in the AWS console, and some steps in the cost management user interface, keep both applications open in a web browser.
 
-Add your AWS source to cost management from 
+Add your AWS source to cost management from the settings area at
 https://cloud.redhat.com/beta/settings/sources/.
 
 [NOTE]

--- a/downstream/modules/enabling_aws_account_access.adoc
+++ b/downstream/modules/enabling_aws_account_access.adoc
@@ -16,32 +16,34 @@ To configure account access:
 +
 ----
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "VisualEditor0",
-            "Effect": "Allow",
-            "Action": [
-                "s3:Get*",
-                "s3:List*"
-            ],
-            "Resource": [
-                "arn:aws:s3:::bucket_name",
-                "arn:aws:s3:::bucket_name/*"
-            ]
-        },
-        {
-            "Sid": "VisualEditor1",
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListAllMyBuckets",
-                "iam:ListAccountAliases",
-                "s3:HeadBucket",
-                "cur:DescribeReportDefinitions"
-            ],
-            "Resource": "*"
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "VisualEditor0",
+      "Effect": "Allow",
+      "Action": [
+        "s3:Get*",
+        "s3:List*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::bucket",
+        "arn:aws:s3:::bucket/*"
+      ]
+    },
+    {
+      "Sid": "VisualEditor1",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListAllMyBuckets",
+        "iam:ListAccountAliases",
+        "s3:HeadBucket",
+        "cur:DescribeReportDefinitions",
+        "organizations:List*",
+        "organizations:Describe*"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 ----
 +


### PR DESCRIPTION
A fix found by Chris Hambridge (sent via #koku-dev Slack).

@dayle I notice our docs are not correct for the AWS Policy: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/getting_started_with_cost_management/assembly_adding_sources_cost#adding_an_aws_source
Sources wizard has the correct info, so just the doc needs updating:
{
	"Version": "2012-10-17",
	"Statement": [{
		"Sid": "VisualEditor0",
		"Effect": "Allow",
		"Action": ["s3:Get*", "s3:List*"],
		"Resource": ["arn:aws:s3:::bucket_name", "arn:aws:s3:::bucket_name/*"]
	}, {
		"Sid": "VisualEditor1",
		"Effect": "Allow",
		"Action": ["s3:ListAllMyBuckets", "iam:ListAccountAliases", "s3:HeadBucket", "cur:DescribeReportDefinitions", "organizations:List*", "organizations:Describe*"],
		"Resource": "*"
	}]
}