### PR TITLE
Ocp4.6 linkupdate

### DIFF
--- a/downstream/assemblies/assembly_configuring_tags_sources.adoc
+++ b/downstream/assemblies/assembly_configuring_tags_sources.adoc
@@ -22,8 +22,8 @@ ifdef::context[:parent-context: {context}]
 
 In order to control which tags cost management imports, activate or enable the tags you want to view by source:
 
-* AWS tags must be activated, and are then selected and exported to cost management in the Cost and Usage report. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/getting_started_with_cost_management/index#activating_aws_tags[Activating AWS tags for cost management] in the _Getting started with cost management_ guide for instructions. 
-* Azure tags are exported to cost management in the cost export report configured in https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/getting_started_with_cost_management/index#configuring_an_azure_daily_export_schedule[Configuring a daily Azure data export schedule] in _Getting started with cost management_.
+* AWS tags must be activated, and are then selected and exported to cost management in the Cost and Usage report. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/getting_started_with_cost_management/index#activating_aws_tags[Activating AWS tags for cost management] in the _Getting started with cost management_ guide for instructions. 
+* Azure tags are exported to cost management in the cost export report configured in https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/getting_started_with_cost_management/index#configuring_an_azure_daily_export_schedule[Configuring a daily Azure data export schedule] in _Getting started with cost management_.
 * OpenShift Container Platform labels are exported by Metering and included in the metrics reports that cost management uses as input. Enable tag key grouping in the _cloud.redhat.com_ application settings to specify which tags to group your cost data by. See xref:enabling_tag_grouping_OCP[] for instructions.
 
 

--- a/downstream/assemblies/assembly_cost_management_next_steps.adoc
+++ b/downstream/assemblies/assembly_cost_management_next_steps.adoc
@@ -25,7 +25,7 @@ The cost management application tracks cloud and infrastructure costs using tags
 Tags and labels can only be configured directly on a source. You cannot edit tags and labels in the cost management application.
 ====
 
-See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/managing_cost_data_using_tagging/index[_Managing cost data using tagging_] to learn more about: 
+See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/managing_cost_data_using_tagging/index[_Managing cost data using tagging_] to learn more about: 
 
 * Planning your tagging strategy to organize your view of cost data
 * Understanding how cost management associates tags
@@ -44,7 +44,7 @@ From the https://cloud.redhat.com/cost-management/cost-models[Cost models] area 
 * Classify your costs as infrastructure or supplementary costs
 * Capture monthly costs for OpenShift nodes and clusters
 * Apply a markup to account for additional support costs
-* Learn how to configure a cost model in https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/using_cost_models/index[_Using cost models_]. 
+* Learn how to configure a cost model in https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/using_cost_models/index[_Using cost models_]. 
 
 
 

--- a/downstream/assemblies/assembly_managing_cost_data_tagging.adoc
+++ b/downstream/assemblies/assembly_managing_cost_data_tagging.adoc
@@ -46,7 +46,7 @@ After adding your sources to cost management:
 
 [NOTE]
 ====
-See the https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/getting_started_with_cost_management/index[_Getting started with cost management_] guide for instructions on configuring sources.
+See the https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/getting_started_with_cost_management/index[_Getting started with cost management_] guide for instructions on configuring sources.
 ====
 
 include::../modules/con_how_cost_associates_tags.adoc[leveloffset=+1]

--- a/downstream/modules/adding_tags_to_an_OCP_resource.adoc
+++ b/downstream/modules/adding_tags_to_an_OCP_resource.adoc
@@ -21,7 +21,7 @@ The AWS or Azure tag equivalent in OpenShift is a label, which also consists of 
 //Module title changed to "Viewing" because users cannot add. Change back to "Adding" when that capability is restored.
 
 ////
-One method of adding tags to OpenShift resources is to specify labels to add in a template. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/images/using-templates[Using templates] in the OpenShift Container Platform documentation.
+One method of adding tags to OpenShift resources is to specify labels to add in a template. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/images/using-templates[Using templates] in the OpenShift Container Platform documentation.
 
 Or to add labels manually:
 
@@ -51,5 +51,5 @@ To view the available tags, navigate to a resource in the OpenShift web console.
 ////
 .Additional resources
 
-For more information about creating OpenShift labels, see https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/nodes/index#nodes-nodes-working-updating_nodes-nodes-working[Nodes] in the OpenShift Container Platform documentation.
+For more information about creating OpenShift labels, see https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/nodes/index#nodes-nodes-working-updating_nodes-nodes-working[Nodes] in the OpenShift Container Platform documentation.
 ////

--- a/downstream/modules/con_cost_model_workflow.adoc
+++ b/downstream/modules/con_cost_model_workflow.adoc
@@ -30,6 +30,6 @@ image:../images/costmodel-workflow.png[]
 
 [NOTE]
 ====
-For more information about configuring tagging for cost management, see https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/managing_cost_data_using_tagging/index[_Using tagging to manage cost data_]. 
+For more information about configuring tagging for cost management, see https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/managing_cost_data_using_tagging/index[_Using tagging to manage cost data_]. 
 ====
 

--- a/downstream/modules/con_cost_model_workflow.adoc
+++ b/downstream/modules/con_cost_model_workflow.adoc
@@ -30,6 +30,6 @@ image:../images/costmodel-workflow.png[]
 
 [NOTE]
 ====
-For more information about configuring tagging for cost management, see https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/managing_cost_data_using_tagging/index[_Using tagging to manage cost data_]. 
+For more information about configuring tagging for cost management, see https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/managing_cost_data_using_tagging/index[_Managing cost data using tagging_]. 
 ====
 

--- a/downstream/modules/configuring_cost_mgmt-operator.adoc
+++ b/downstream/modules/configuring_cost_mgmt-operator.adoc
@@ -79,7 +79,7 @@ For both methods of authentication, the name of the secret should match the _aut
 +
 . Configure the Metering Operator.
 +
-Cost management uses the Metering Operator to create, collect, package, and upload metrics to cost management. In order for metering to work properly, configure `operator-metering` using the https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/metering/index#configuring-metering[OpenShift documentation] to create a MeteringConfig resource.
+Cost management uses the Metering Operator to create, collect, package, and upload metrics to cost management. In order for metering to work properly, configure `operator-metering` using the https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/metering/index#configuring-metering[OpenShift documentation] to create a MeteringConfig resource.
 +
 . Configure the Cost Management Operator by creating the `CostManagement` and `CostManagementData` custom resources.
 +
@@ -161,4 +161,4 @@ The cluster identifier can be found in *Help* > *About* in OpenShift.
 
 .Additional resources
 
-* See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/operators/olm-understanding-operatorhub[Operators] in the OpenShift documentation for more information about Operators and OperatorHub
+* See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/operators/olm-understanding-operatorhub[Operators] in the OpenShift documentation for more information about Operators and OperatorHub

--- a/downstream/modules/configuring_cost_mgmt-operator.adoc
+++ b/downstream/modules/configuring_cost_mgmt-operator.adoc
@@ -161,4 +161,4 @@ The cluster identifier can be found in *Help* > *About* in OpenShift.
 
 .Additional resources
 
-* See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/operators/olm-understanding-operatorhub[Operators] in the OpenShift documentation for more information about Operators and OperatorHub
+* See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/operators[Operators] in the OpenShift documentation for more information about Operators and OperatorHub.

--- a/downstream/modules/creating_an_AWS_Azure_cost_model.adoc
+++ b/downstream/modules/creating_an_AWS_Azure_cost_model.adoc
@@ -19,8 +19,8 @@ This example shows how to add a 10% markup to the information collected from the
 
 .Prerequisites
 
-* A user with Cost Administrator or Cost Price List Administrator permissions. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/getting_started_with_cost_management/assembly_limiting_access_cost_resources_rbac[Limiting access to cost management resources] in _Getting started with cost management_ for instructions on configuring user roles.
-* Your AWS account added to cost management as a data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/getting_started_with_cost_management/assembly_adding_sources_cost[Adding an Amazon Web Services (AWS) source to cost management] in _Getting started with cost management_ for instructions.
+* A user with Cost Administrator or Cost Price List Administrator permissions. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/getting_started_with_cost_management/assembly_limiting_access_cost_resources_rbac[Limiting access to cost management resources] in _Getting started with cost management_ for instructions on configuring user roles.
+* Your AWS account added to cost management as a data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/getting_started_with_cost_management/assembly_adding_sources_cost[Adding an Amazon Web Services (AWS) source to cost management] in _Getting started with cost management_ for instructions.
 
 
 .Procedure
@@ -52,7 +52,7 @@ Your new cost model will appear in the list on the *Cost models* page.
 +
 ** From the *Cost models* summary page, click image:more-options.png[] (*more options*), then *View details* or *Delete* the cost model. From the *View details* option, you can edit the cost model, including source assignments, markup, and other settings.
 
-* Review your tags and tagging strategy to ensure that costs are being distributed to the correct resources, cost centers, or teams. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/managing_cost_data_using_tagging/index[_Using tagging to manage cost data_] for more information.
+* Review your tags and tagging strategy to ensure that costs are being distributed to the correct resources, cost centers, or teams. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/managing_cost_data_using_tagging/index[_Using tagging to manage cost data_] for more information.
 
 
 

--- a/downstream/modules/creating_an_AWS_Azure_cost_model.adoc
+++ b/downstream/modules/creating_an_AWS_Azure_cost_model.adoc
@@ -52,7 +52,9 @@ Your new cost model will appear in the list on the *Cost models* page.
 +
 ** From the *Cost models* summary page, click image:more-options.png[] (*more options*), then *View details* or *Delete* the cost model. From the *View details* option, you can edit the cost model, including source assignments, markup, and other settings.
 
-* Review your tags and tagging strategy to ensure that costs are being distributed to the correct resources, cost centers, or teams. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/managing_cost_data_using_tagging/index[_Using tagging to manage cost data_] for more information.
+* Review your tags and tagging strategy to ensure that costs are being distributed to the correct resources, cost centers, or teams. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/managing_cost_data_using_tagging/index[_Managing cost data using tagging_] for more information.
+
+
 
 
 

--- a/downstream/modules/creating_an_OCP_onprem_cost_model.adoc
+++ b/downstream/modules/creating_an_OCP_onprem_cost_model.adoc
@@ -27,8 +27,8 @@ This example shows how to design and apply a cost model to your OpenShift on-pre
 
 .Prerequisites
 
-* A user with Cost Administrator or Cost Price List Administrator permissions. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/getting_started_with_cost_management/assembly_limiting_access_cost_resources_rbac[Limiting access to cost management resources] in _Getting started with cost management_ for instructions on configuring user roles.
-* Your OpenShift cluster added as a cost management data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/getting_started_with_cost_management/assembly_adding_sources_cost#assembly_adding_ocp_sources[Adding an OpenShift Container Platform source to cost management] in _Getting started with cost management_ for instructions.
+* A user with Cost Administrator or Cost Price List Administrator permissions. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/getting_started_with_cost_management/assembly_limiting_access_cost_resources_rbac[Limiting access to cost management resources] in _Getting started with cost management_ for instructions on configuring user roles.
+* Your OpenShift cluster added as a cost management data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/getting_started_with_cost_management/assembly_adding_sources_cost#assembly_adding_ocp_sources[Adding an OpenShift Container Platform source to cost management] in _Getting started with cost management_ for instructions.
 
 .Procedure
 
@@ -74,5 +74,5 @@ Your new cost model will appear in the list on the *Cost models* page.
 +
 ** From the *Cost models* summary page, click image:more-options.png[] (*more options*), then *View details* or *Delete* the cost model. From the *View details* option, you can edit the cost model, including source assignments, markup, and other settings.
 
-* Review your tags and tagging strategy to ensure that costs are being distributed to the correct resources, cost centers, or teams. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/managing_cost_data_using_tagging/index[_Using tagging to manage cost data_] for more information.
+* Review your tags and tagging strategy to ensure that costs are being distributed to the correct resources, cost centers, or teams. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/managing_cost_data_using_tagging/index[_Using tagging to manage cost data_] for more information.
 

--- a/downstream/modules/creating_an_OCP_onprem_cost_model.adoc
+++ b/downstream/modules/creating_an_OCP_onprem_cost_model.adoc
@@ -74,5 +74,5 @@ Your new cost model will appear in the list on the *Cost models* page.
 +
 ** From the *Cost models* summary page, click image:more-options.png[] (*more options*), then *View details* or *Delete* the cost model. From the *View details* option, you can edit the cost model, including source assignments, markup, and other settings.
 
-* Review your tags and tagging strategy to ensure that costs are being distributed to the correct resources, cost centers, or teams. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/managing_cost_data_using_tagging/index[_Using tagging to manage cost data_] for more information.
+* Review your tags and tagging strategy to ensure that costs are being distributed to the correct resources, cost centers, or teams. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/managing_cost_data_using_tagging/index[_Managing cost data using tagging_] for more information.
 

--- a/downstream/modules/enabling_tag_grouping_OCP.adoc
+++ b/downstream/modules/enabling_tag_grouping_OCP.adoc
@@ -19,7 +19,7 @@ To group your cost data by tag key, you must enable the tag keys in the cloud.re
 
 .Prerequisites
 
-* You must have Organization Administrator privileges to change these settings in cost management. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/getting_started_with_cost_management/index#assembly_cost_limiting_access_rbac[Limiting access to cost management resources] in _Getting started with cost management_ for more information about user roles and access.
+* You must have Organization Administrator privileges to change these settings in cost management. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/getting_started_with_cost_management/index#assembly_cost_limiting_access_rbac[Limiting access to cost management resources] in _Getting started with cost management_ for more information about user roles and access.
 
 .Procedure
 //Updated July 20, 2020 to match current Applications tab in Settings

--- a/downstream/modules/exporting_cost_data_reporting.adoc
+++ b/downstream/modules/exporting_cost_data_reporting.adoc
@@ -18,8 +18,8 @@ This example shows how to view data for specific OpenShift resources, and export
 
 .Prerequisites
 
-* Your OpenShift cluster added as a cost management data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/getting_started_with_cost_management/assembly_adding_sources_cost#assembly_adding_ocp_sources[Adding an OpenShift Container Platform source to cost management] in _Getting started with cost management_ for instructions.
-* Your cloud infrastructure account added as a cost management data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/getting_started_with_cost_management/assembly_adding_sources_cost[Adding sources to cost management] in _Getting started with cost management_ for instructions for your cloud provider type.
+* Your OpenShift cluster added as a cost management data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/getting_started_with_cost_management/assembly_adding_sources_cost#assembly_adding_ocp_sources[Adding an OpenShift Container Platform source to cost management] in _Getting started with cost management_ for instructions.
+* Your cloud infrastructure account added as a cost management data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/getting_started_with_cost_management/assembly_adding_sources_cost[Adding sources to cost management] in _Getting started with cost management_ for instructions for your cloud provider type.
 * Configure tags on your sources. For tips and configuration instructions, see xref:assembly_configuring_tags_sources[].
 
 .Procedure

--- a/downstream/modules/filtering_cost_data_views.adoc
+++ b/downstream/modules/filtering_cost_data_views.adoc
@@ -22,8 +22,8 @@ This example shows how to see how much each OpenShift project within a cluster i
 
 .Prerequisites
 
-* Your OpenShift cluster added as a cost management data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/getting_started_with_cost_management/assembly_adding_sources_cost#assembly_adding_ocp_sources[Adding an OpenShift Container Platform source to cost management] in _Getting started with cost management_ for instructions.
-* Your cloud infrastructure account added as a cost management data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/getting_started_with_cost_management/assembly_adding_sources_cost[Adding sources to cost management] in _Getting started with cost management_ for instructions for your cloud provider type.
+* Your OpenShift cluster added as a cost management data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/getting_started_with_cost_management/assembly_adding_sources_cost#assembly_adding_ocp_sources[Adding an OpenShift Container Platform source to cost management] in _Getting started with cost management_ for instructions.
+* Your cloud infrastructure account added as a cost management data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/getting_started_with_cost_management/assembly_adding_sources_cost[Adding sources to cost management] in _Getting started with cost management_ for instructions for your cloud provider type.
 * Configure tags on your sources. For tips and configuration instructions, see xref:assembly_configuring_tags_sources[].
 
 .Procedure

--- a/downstream/modules/grouping_cost_data_tag_category.adoc
+++ b/downstream/modules/grouping_cost_data_tag_category.adoc
@@ -23,8 +23,8 @@ This example shows how an educational course provider who is running a lab envir
 
 .Prerequisites
 
-* Your OpenShift cluster added as a cost management data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/getting_started_with_cost_management/assembly_adding_sources_cost#assembly_adding_ocp_sources[Adding an OpenShift Container Platform source to cost management] in _Getting started with cost management_ for instructions.
-* Your cloud infrastructure account added as a cost management data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/getting_started_with_cost_management/assembly_adding_sources_cost[Adding sources to cost management] in _Getting started with cost management_ for instructions for your cloud provider type.
+* Your OpenShift cluster added as a cost management data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/getting_started_with_cost_management/assembly_adding_sources_cost#assembly_adding_ocp_sources[Adding an OpenShift Container Platform source to cost management] in _Getting started with cost management_ for instructions.
+* Your cloud infrastructure account added as a cost management data source. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/getting_started_with_cost_management/assembly_adding_sources_cost[Adding sources to cost management] in _Getting started with cost management_ for instructions for your cloud provider type.
 * Configure tags on your sources. For tips and configuration instructions, see xref:assembly_configuring_tags_sources[].
 * OpenShift tag grouping enabled. See xref:enabling_tag_grouping_OCP[] for instructions.
 

--- a/downstream/modules/installing_cost_mgmt-operator.adoc
+++ b/downstream/modules/installing_cost_mgmt-operator.adoc
@@ -10,7 +10,7 @@ Begin adding your OpenShift Container Platform cluster as a source to cost manag
 
 [NOTE]
 ====
-See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/operators/olm-understanding-operatorhub[Operators] in the OpenShift documentation for more information about Operators and OperatorHub.
+See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/operators/olm-understanding-operatorhub[Operators] in the OpenShift documentation for more information about Operators and OperatorHub.
 ====
 
 .Prerequisites
@@ -31,10 +31,10 @@ See https://access.redhat.com/documentation/en-us/openshift_container_platform/4
 You must install the Cost Management Operator in the `openshift-metering` namespace. Other namespaces are not supported for installation.
 ====
 +
-See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/operators/olm-adding-operators-to-a-cluster[Adding operators to a cluster] in the OpenShift documentation for instructions for installing an Operator.
+See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/operators/olm-adding-operators-to-a-cluster[Adding operators to a cluster] in the OpenShift documentation for instructions for installing an Operator.
 
 
 .Additional resources
 
-* See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/metering/index[Metering] in the OpenShift documentation for more information about installing Metering.
+* See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/metering/index[Metering] in the OpenShift documentation for more information about installing Metering.
 

--- a/downstream/modules/installing_cost_mgmt-operator.adoc
+++ b/downstream/modules/installing_cost_mgmt-operator.adoc
@@ -10,7 +10,7 @@ Begin adding your OpenShift Container Platform cluster as a source to cost manag
 
 [NOTE]
 ====
-See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/operators/olm-understanding-operatorhub[Operators] in the OpenShift documentation for more information about Operators and OperatorHub.
+See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/operators[Operators] in the OpenShift documentation for more information about Operators and OperatorHub.
 ====
 
 .Prerequisites
@@ -31,10 +31,10 @@ See https://access.redhat.com/documentation/en-us/openshift_container_platform/4
 You must install the Cost Management Operator in the `openshift-metering` namespace. Other namespaces are not supported for installation.
 ====
 +
-See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/operators/olm-adding-operators-to-a-cluster[Adding operators to a cluster] in the OpenShift documentation for instructions for installing an Operator.
+See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/operators/administrator-tasks#olm-adding-operators-to-a-cluster[Adding Operators to a cluster] in the OpenShift documentation for instructions for installing an Operator.
 
 
 .Additional resources
 
-* See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/metering/index[Metering] in the OpenShift documentation for more information about installing Metering.
+* See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/metering[Metering] in the OpenShift documentation for more information about installing Metering.
 

--- a/downstream/titles/exporting_data_using_the_API/master-docinfo.xml
+++ b/downstream/titles/exporting_data_using_the_API/master-docinfo.xml
@@ -1,6 +1,6 @@
 <title>Exporting cost data using the API</title>
 <productname>OpenShift Container Platform</productname>
-<productnumber>4.5</productnumber>
+<productnumber>4.6</productnumber>
 <subtitle>Using the data export request API</subtitle>
 <abstract>
    <para>This guide provides instructions for using the data export API to obtain cost data for reporting.</para>

--- a/downstream/titles/getting_started/master-docinfo.xml
+++ b/downstream/titles/getting_started/master-docinfo.xml
@@ -1,6 +1,6 @@
 <title>Getting started with cost management</title>
 <productname>OpenShift Container Platform</productname>
-<productnumber>4.5</productnumber>
+<productnumber>4.6</productnumber>
 <subtitle>Learn about and configure cost management</subtitle>
 <abstract>
     <para>This guide describes the initial steps to begin using cost management.</para></abstract>

--- a/downstream/titles/managing_cost_data_using_tags/master-docinfo.xml
+++ b/downstream/titles/managing_cost_data_using_tags/master-docinfo.xml
@@ -1,6 +1,6 @@
 <title>Managing cost data using tagging</title>
 <productname>OpenShift Container Platform</productname>
-<productnumber>4.5</productnumber>
+<productnumber>4.6</productnumber>
 <subtitle>Organize resources and allocate costs with tags</subtitle>
 <abstract>
     <para>This guide explains how tagging works in cost management, and outlines strategies for managing your cost data with tags and labels.</para>

--- a/downstream/titles/using_cost_models/master-docinfo.xml
+++ b/downstream/titles/using_cost_models/master-docinfo.xml
@@ -1,6 +1,6 @@
 <title>Using cost models</title>
 <productname>OpenShift Container Platform</productname>
-<productnumber>4.5</productnumber>
+<productnumber>4.6</productnumber>
 <subtitle>Configuring cost models to reflect your cloud costs</subtitle>
 <abstract>
     <para>This guide explains the cost model feature, configuration and related terminology.</para>


### PR DESCRIPTION
Updated all OCP 4.5 links to OCP 4.6. Tested links in 3 guides and caught a few that changes URL.