### PR TITLE
Update prefix requirement for AWS CUR

### DIFF
--- a/downstream/modules/creating_an_aws_s3_bucket.adoc
+++ b/downstream/modules/creating_an_aws_s3_bucket.adoc
@@ -13,7 +13,7 @@ Log into your AWS master account to begin configuring cost and usage reporting:
 +
 * Report name: _<any-name>_ (note this name as you will use it later)
 * Additional report details: Include resource IDs
-* S3 bucket: <the S3 bucket you configured previously>
+* S3 bucket: _<the S3 bucket you configured previously>_
 * Time granularity: Hourly
 * Enable report data integration for: Amazon Redshift, Amazon QuickSight (do not enable report data integration for Amazon Athena)
 * Compression type: GZIP

--- a/downstream/modules/creating_an_aws_s3_bucket.adoc
+++ b/downstream/modules/creating_an_aws_s3_bucket.adoc
@@ -11,15 +11,13 @@ Log into your AWS master account to begin configuring cost and usage reporting:
 . In the AWS S3 console, create a new S3 bucket or use an existing bucket. If you are configuring a new S3 bucket, accept the default settings.
 . In the AWS Billing console, create a Cost and Usage Report that will be delivered to your S3 bucket. Specify the following values (and accept the defaults for any other values):
 +
-----
-Report name: _<any-name>_ (note this name as you will use it later)
-Additional report details: Include resource IDs
-S3 bucket: <the S3 bucket you configured previously>
-Time granularity: Hourly
-Enable report data integration for: Amazon Redshift, Amazon QuickSight (do not enable report data integration for Amazon Athena)
-Compression type: GZIP
-Report path prefix: (leave blank)
-----
+* Report name: _<any-name>_ (note this name as you will use it later)
+* Additional report details: Include resource IDs
+* S3 bucket: <the S3 bucket you configured previously>
+* Time granularity: Hourly
+* Enable report data integration for: Amazon Redshift, Amazon QuickSight (do not enable report data integration for Amazon Athena)
+* Compression type: GZIP
+* Report path prefix: cost
 +
 [NOTE]
 ====


### PR DESCRIPTION
Updated the AWS cost and usage report configuration from **Report path prefix: <leave blank>** to **Report path prefix: cost**

And did a bit of reformatting of this list so it doesn't look like CLI output.

![Screenshot 2020-11-10 at 14 28 32](https://user-images.githubusercontent.com/20275317/98680039-25541780-2361-11eb-8032-8b8d3da79f4c.png)
