### PR TITLE
Switch HeadBucket to ListBucket

### DIFF
--- a/downstream/modules/enabling-additional-aws-account-access.adoc
+++ b/downstream/modules/enabling-additional-aws-account-access.adoc
@@ -43,7 +43,7 @@ The following configuration provides access to additional stored information and
       "Effect": "Allow",
       "Action": [
         "iam:ListAccountAliases",
-        "s3:HeadBucket",
+        "s3:ListBucket",
         "cur:DescribeReportDefinitions",
         "organizations:List*",
         "organizations:Describe*"

--- a/downstream/modules/enabling-aws-account-access.adoc
+++ b/downstream/modules/enabling-aws-account-access.adoc
@@ -36,7 +36,7 @@ To provide data within the web interface and API, {product-title} needs to consu
       "Sid": "VisualEditor1",
       "Effect": "Allow",
       "Action": [
-        "s3:HeadBucket",
+        "s3:ListBucket",
         "cur:DescribeReportDefinitions"
       ],
       "Resource": "*"


### PR DESCRIPTION
## Summary
HeadBucket isn't actually a AWS permission. Switching with ListBucket which allows you to make a head call to the bucket.