### PR TITLE
COST-1755 cost model update with some tweaks to RBAC and attributes

### DIFF
--- a/downstream/attributes/cost.adoc
+++ b/downstream/attributes/cost.adoc
@@ -2,7 +2,8 @@
 // Titles
 
 :product-title: cost management
-:platform: link:https://cloud.redhat.com[cloud.redhat.com]
+:platform-title: Red Hat Hybrid Cloud Console
+:platform: link:https://console.redhat.com[console.redhat.com]
 :openshift: OpenShift Container Platform
 :operator: costmanagement-metrics-operator
 :operator-formal: Cost Management Metrics Operator
@@ -44,6 +45,7 @@
 :link-aws: link:https://console.redhat.com/openshift/cost-management/aws[Amazon Web Services]  
 :link-azure: link:https://console.redhat.com/openshift/cost-management/azure[Microsoft Azure]
 :link-gcp: link:https://console.redhat.com/openshift/cost-management/gcp[Google Cloud Platform]
+:link-jira: link:https://issues.redhat.com/projects/COST/[{product-title} Jira board]
 
 // images
 

--- a/downstream/attributes/koku.adoc
+++ b/downstream/attributes/koku.adoc
@@ -1,7 +1,8 @@
 // Titles
 
 :product-title: cost management
-:platform: link:https://cloud.redhat.com[cloud.redhat.com]
+:platform-title: Red Hat Hybrid Cloud Console
+:platform: link:https://console.redhat.com[console.redhat.com]
 :openshift: OpenShift Container Platform
 :operator: koku-metrics-operator
 :operator-formal: Koku Metrics Operator
@@ -40,6 +41,7 @@
 :link-aws: link:https://console.redhat.com/openshift/cost-management/aws[Amazon Web Services]  
 :link-azure: link:https://console.redhat.com/openshift/cost-management/azure[Microsoft Azure]
 :link-gcp: link:https://console.redhat.com/openshift/cost-management/gcp[Google Cloud Platform]
+:link-jira: link:https://issues.redhat.com/projects/COST/[{product-title} Jira board]
 
 // images 
 

--- a/downstream/modules/creating-an-aws-azure-cost-model.adoc
+++ b/downstream/modules/creating-an-aws-azure-cost-model.adoc
@@ -16,6 +16,11 @@ Adding a markup to your _raw costs_ can allow you to account for your overhead c
 
 This example shows how to add a 10% markup to the information collected from the AWS Cost and Usage Reports. The same method can be used to apply a markup or discount to your Azure or Google Cloud costs.
 
+[NOTE]
+====
+Creating, editing, or deleting a cost model only updates calculations starting from the first day of the current month.  
+====
+
 .Prerequisites
 
 * A user with Cost Administrator or Cost Price List Administrator permissions. See _{link-limiting-access}_ in _Getting started with cost management_ for instructions on configuring user roles.

--- a/downstream/modules/creating-an-ocp-cost-model.adoc
+++ b/downstream/modules/creating-an-ocp-cost-model.adoc
@@ -14,6 +14,10 @@ Creating a cost model for an OpenShift source includes assigning prices for usag
 
 This example shows how to design and apply a cost model for an OpenShift Container Platform cluster on cloud infrastructure (for example, AWS or Azure). The cloud infrastructure costs are seen in {product-title} as part of the cluster cost, so creating a cost model allows you to distribute the underlying infrastructure cost to accurately reflect the costs of running the cluster.
 
+[NOTE]
+====
+Creating, editing, or deleting a cost model only updates calculations starting from the first day of the current month.  
+====
 ////
 * How to account for monthly OpenShift cluster and node costs
 * How to assign rates to OpenShift metrics and usage

--- a/downstream/modules/default-user-roles.adoc
+++ b/downstream/modules/default-user-roles.adoc
@@ -17,6 +17,7 @@ To use a default role, determine the required level of access to permit your use
 
 * Cost Administrator:  has read and write permissions to all resources in {product-title}
 * Cost Price List Administrator:  has read and write permissions on price list rates
+* Sources Administrator: has create and edit permissions for managing sources 
 
 .Viewer roles
 

--- a/downstream/modules/note-bugzilla.adoc
+++ b/downstream/modules/note-bugzilla.adoc
@@ -7,4 +7,4 @@
 [id="note-bugzilla_{context}"]
 
 [role="_abstract"]
-If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at link:https://bugzilla.redhat.com/enter_bug.cgi?product=Cloud%20Software%20Services%20(cloud.redhat.com)&component=Cost%20Management[http://bugzilla.redhat.com] against _Cloud Software Services ({platform})_ for the *{product-title}* component.
+If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at link:https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20Hybrid%20Cloud%20Console%20%28console.redhat.com%29[http://bugzilla.redhat.com] against _{platform-title} ({platform})_ for the *{product-title}* component. Alternatively, you can open an issue in the {link-jira} with the *Documentation* label.


### PR DESCRIPTION
Added a new note to inform customer how the cost models are calculated in the procedures. 

Also renamed :platform: to the "Red Hat Hybrid Cloud Console" per the newest marketing guidance. 

This update also mentions to customers how they can open a documentation ticket in Jira for potential docs issues and points to the hybrid console product instead of cloud. 





<img width="802" alt="Screen Shot 2021-08-23 at 14 27 10" src="https://user-images.githubusercontent.com/49633268/130450147-510397b6-0bbb-4194-ba74-690b0bd761e9.png">
