### PR TITLE
Resource level GCP Big Query Processing.

### DIFF
--- a/downstream/modules/exporting-billing-data-gcp.adoc
+++ b/downstream/modules/exporting-billing-data-gcp.adoc
@@ -21,10 +21,10 @@ Enabling a billing export to BigQuery sends your Google Cloud billing data (such
 
 . Navigate to menu:Billing[Billing export] in link:https://console.cloud.google.com/[Google Cloud Console].
 . Click the *BIGQUERY EXPORT* tab.
-. Click btn:[EDIT SETTINGS] in the *Daily cost detail* section.
+. Click btn:[EDIT SETTINGS] in the *Detailed usage cost* section.
 . Select the {product-title} *Project* and *Billing export dataset* you created in the dropdown menus.
 . Click btn:[SAVE].
 
 .Verification steps
 
-. Verify a green checkmark with *Enabled* in the *Daily cost detail* section, with correct *Project name* and *Dataset name*.
+. Verify a green checkmark with *Enabled* in the *Detailed usage cost* section, with correct *Project name* and *Dataset name*.


### PR DESCRIPTION
Update the GCP export docs to use `Detailed usage cost` instead of the old "daily cost detail".